### PR TITLE
play a sample song for an artist

### DIFF
--- a/messages/index.js
+++ b/messages/index.js
@@ -191,6 +191,53 @@ var intents = new builder.IntentDialog({ recognizers: [recognizer] })
             }
         }
     ])
+    .matches('getSong', [
+        function (session, args, next)  {
+            var band = builder.EntityRecognizer.findEntity(args.entities, 'band');
+            if (!band) {
+                builder.Prompts.text(session, "What artist/band are you looking for?");
+            } else {
+                next({ response: band.entity });
+            }
+        },
+        function (session, results) {
+            if (! results.response) {
+                session.send('Ok');
+            }
+            var eventData = getArtist(results.response);
+
+            if(!eventData) {
+                session.send('Sorry, I could not find the artist \'%s\'.', result.response);
+                return;
+            }
+            var band = eventData.description;
+
+            request.get({
+                url: 'https://api.spotify.com/v1/search',
+                qs: {
+                    q: band,
+                    type: 'artist,track'
+                }
+            },
+            function (error, response, body) {
+                if (error || response.statusCode != 200) {
+                    session.send('Sorry, there was an error.');
+                }
+                body = JSON.parse(body);
+                songSpotifyURL = body.artists.items[0].external_urls.spotify;
+                imageURL = body.artists.items[0].images[0].url;
+                var card = new builder.HeroCard(session)
+                    .title(band)
+                    .text(eventData.text)
+                    .images([builder.CardImage.create(session, imageURL)])
+                    .buttons([
+                        builder.CardAction.openUrl(session, songSpotifyURL, 'Play on Spotify')
+                    ]);
+
+                session.send(new builder.Message(session).addAttachment(card));
+            });
+        }
+    ])
     .onDefault((session) => {
         session.send('Sorry, I did not understand \'%s\'.', session.message.text);
     });
@@ -221,10 +268,3 @@ if (useEmulator) {
 } else {
     module.exports = { default: connector.listen() }
 }
-
-
-
-
-
-
-

--- a/messages/package.json
+++ b/messages/package.json
@@ -7,7 +7,8 @@
     "botbuilder": "^3.4.2",
     "botbuilder-azure": "0.0.1",
     "botbuilder-location": "^1.0.2",
-    "did-you-mean": "0.0.1"
+    "did-you-mean": "0.0.1",
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "restify": "^4.1.1"


### PR DESCRIPTION
Using Spotify open APIs. No credentials required.

Intents to be added:
```json
    {
      "name": "getSong"
    }
```

Utterances to be added:
```json

    {
        "text":"play me a song from youngr",
        "intent":"getSong",
        "entities":[
            {
                "entity":"band",
                "startPos":5,
                "endPos":5
            }
        ]
    },
    {
        "text":"play something from youngr",
        "intent":"getSong",
        "entities":[
            {
                "entity":"band",
                "startPos":3,
                "endPos":3
            }
        ]
    },
    {
        "text":"play youngr",
        "intent":"getSong",
        "entities":[
            {
                "entity":"band",
                "startPos":1,
                "endPos":1
            }
        ]
    }

```