### PR TITLE
Added QnA Maker preview query to onDefault

### DIFF
--- a/messages/index.js
+++ b/messages/index.js
@@ -308,7 +308,24 @@ var intents = new builder.IntentDialog({ recognizers: [recognizer] })
     ])
 
     .onDefault((session) => {
-        session.send('Sorry, I did not understand \'%s\'.', session.message.text);
+        request.post({
+            url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v1.0/knowledgebases/' + process.env['knowledgeBaseId'] + '/generateAnswer',
+            headers: {
+                'Ocp-Apim-Subscription-Key': process.env['ocpApimSubscriptionKey'],
+                'Content-Type': 'application/json'
+            },
+            body: {
+                'question': session.message.text
+            },
+            json: true
+        }, function(error, response, body ){
+           if (error || response.statusCode != 200 || body.score < 90 ) {
+                session.send('Sorry, I did not understand \'%s\'.', session.message.text);
+            }
+            else{
+                session.send(body.answer)
+            }
+        });
     })
     .onBegin(function (session, args, next) {
         // session.dialogData.name = args.name;


### PR DESCRIPTION
This change adds a fallback strategy to questions that were not in the defined intents by searching the noorderslag FAQ created in the QnA Maker preview and replying with the answer found if it's score is equal or greater than 90.

To merge this change 

Please create a new QNA using the qnamaker.ai website based on the information in the page:
https://www.eurosonic-noorderslag.nl/en/info/faq/

and then add to the environment variables the following keys:
- knowledgeBaseId
- ocpApimSubscriptionKey